### PR TITLE
Add State Abbreviation Support

### DIFF
--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -16,8 +16,11 @@ document.addEventListener("DOMContentLoaded", function() {
 async function getData() {
     document.getElementById("results").innerHTML = "Loading...";
 
-    const state  = document.getElementById("state").value;
-    const county = document.getElementById("county").value;
+    var state  = document.getElementById("state").value;
+    var county = document.getElementById("county").value;
+
+    if(state.length < 3)
+        state = getFullStateName(state.toUpperCase());
 
     const params = new URLSearchParams();
     params.append('state', state);
@@ -34,6 +37,9 @@ async function getData() {
 // A function to Print / Display the data we got
 function display(data, state, county) {
     var results = document.getElementById("results");
+
+    state  = state.charAt(0).toUpperCase()  + state.slice(1);
+    county = county.charAt(0).toUpperCase() + county.slice(1);
 
     if(data.hasOwnProperty('error')) {
         results.innerHTML = "Location not found.";
@@ -54,3 +60,62 @@ function display(data, state, county) {
         results.innerHTML += "<b>" + totalDeaths.toLocaleString() + "</b> deaths this past week.";
     }
 } 
+
+// retrieve full name from state abbreviation  NJ --> New Jersey
+function getFullStateName(state) {
+    return stateList[state];
+}
+
+const stateList = {
+    AZ: 'Arizona',
+    AL: 'Alabama',
+    AK: 'Alaska',
+    AR: 'Arkansas',
+    CA: 'California',
+    CO: 'Colorado',
+    CT: 'Connecticut',
+    DC: 'District of Columbia',
+    DE: 'Delaware',
+    FL: 'Florida',
+    GA: 'Georgia',
+    HI: 'Hawaii',
+    ID: 'Idaho',
+    IL: 'Illinois',
+    IN: 'Indiana',
+    IA: 'Iowa',
+    KS: 'Kansas',
+    KY: 'Kentucky',
+    LA: 'Louisiana',
+    ME: 'Maine',
+    MD: 'Maryland',
+    MA: 'Massachusetts',
+    MI: 'Michigan',
+    MN: 'Minnesota',
+    MS: 'Mississippi',
+    MO: 'Missouri',
+    MT: 'Montana',
+    NE: 'Nebraska',
+    NV: 'Nevada',
+    NH: 'New Hampshire',
+    NJ: 'New Jersey',
+    NM: 'New Mexico',
+    NY: 'New York',
+    NC: 'North Carolina',
+    ND: 'North Dakota',
+    OH: 'Ohio',
+    OK: 'Oklahoma',
+    OR: 'Oregon',
+    PA: 'Pennsylvania',
+    RI: 'Rhode Island',
+    SC: 'South Carolina',
+    SD: 'South Dakota',
+    TN: 'Tennessee',
+    TX: 'Texas',
+    UT: 'Utah',
+    VT: 'Vermont',
+    VA: 'Virginia',
+    WA: 'Washington',
+    WV: 'West Virginia',
+    WI: 'Wisconsin',
+    WY: 'Wyoming'
+}


### PR DESCRIPTION
Nice quick fix that allows users to input their state abbreviation instead of the full state name. Uses a dictionary, handled by JS. Also added polish through automatic capitalization to make sure that state and county names are always capitalized.